### PR TITLE
Fix ValueError: year is out of range

### DIFF
--- a/pynetdot/fields.py
+++ b/pynetdot/fields.py
@@ -58,7 +58,7 @@ class BoolField(BaseField):
 
 class DateField(BaseField):
     def _clean(self, v):
-        if not v or v == '':
+        if not v or v == '' or v == '0000-00-00':
             return None
         date = datetime_parser.parse(v)
         return date.date()


### PR DESCRIPTION
Fix for "ValueError: year is out of range" when some entries with dates
like '0000-00-00'